### PR TITLE
two trivial fixes

### DIFF
--- a/bytestructures/body/numeric.scm
+++ b/bytestructures/body/numeric.scm
@@ -233,7 +233,7 @@
               (lp64 int64)
               (else int32)))
 
-(define unsigpend-long (cond-expand
+(define unsigned-long (cond-expand
                         (lp64 uint64)
                         (else uint32)))
 

--- a/bytestructures/r7/numeric-all.sld
+++ b/bytestructures/r7/numeric-all.sld
@@ -1,6 +1,7 @@
 (define-library (bytestructures r7 numeric-all)
   (import
    (scheme base)
+   (scheme complex)
    (bytestructures r7 utils)
    (bytestructures r7 base)
    (bytestructures r7 bytevectors)


### PR DESCRIPTION
This pull request fixes a typo of the word 'unsigned-long' and imports (scheme complex) into the numeric-all r7 module, for access to the symbols real-part, imag-part, and make-rectangular.