### PR TITLE
build: Fix cross-compilation.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,4 +12,9 @@ GUILE_PROGS
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([pre-inst-env], [chmod +x pre-inst-env])
 
+if test "$cross_compiling" != no; then
+   GUILE_TARGET="--target=$host_alias"
+   AC_SUBST([GUILE_TARGET])
+fi
+
 AC_OUTPUT

--- a/guile.am
+++ b/guile.am
@@ -11,4 +11,4 @@ EXTRA_DIST = $(SOURCES) $(NOCOMP_SOURCES)
 GUILE_WARNINGS = -Wunbound-variable -Warity-mismatch -Wformat
 SUFFIXES = .scm .go
 .scm.go:
-	$(AM_V_GEN)$(top_builddir)/pre-inst-env $(GUILE_TOOLS) compile $(GUILE_WARNINGS) -o "$@" "$<"
+	$(AM_V_GEN)$(top_builddir)/pre-inst-env $(GUILE_TOOLS) compile $(GUILE_TARGET) $(GUILE_WARNINGS) -o "$@" "$<"


### PR DESCRIPTION
* configure.ac: Set GUILE_TARGET when cross-compiling.
* guile.am (.scm.go): Pass GUILE_TARGET variable to guild.