### PR TITLE
Fix alignment in unpacked structs containing unions. (Closes: #47)

### DIFF
--- a/bytestructures/body/struct.scm
+++ b/bytestructures/body/struct.scm
@@ -107,7 +107,6 @@
     (let ((descriptor (cadr field-spec)))
       (bytestructure-descriptor-size descriptor)))
   (let* ((alignment (apply max (map field-spec-alignment field-specs)))
-         (alignment (pack-alignment pack alignment))
          (size (apply max (map field-spec-size field-specs)))
          (position (align position size (pack-alignment pack alignment))))
     (let loop ((field-specs field-specs)


### PR DESCRIPTION
The 2.0.1 release suffered from a test failure [1] that caused some distributions to disable the test [2] but the underlying cause had yet to be identified.

Based on a preliminary review of the code, the author of this commit believes there was a surplus line in the code [3] which is deleted here.  This is the proposed evidence: The line shadowed the 'alignment' variable in line immediately above it. [4] Then, the same expression was used two lines down below. [5] In combination, the line being removed here seems to have been left over from editing under time pressure. It may also have been added inadvertently.

On GNU Guix, this commit fixes the 'ref1' test for aligned struct bytestructures containing union members, which was referenced via "run-tests.body.scm:194: FAIL ref1" in Ludo's original report. [6] The test output can be found at the bottom of this message.

This commit closes Github issue #47. [7]

[1] https://issues.guix.gnu.org/54165#1
[2] https://github.com/alpinelinux/aports/commit/2d8604645ca38552343c61fbc65728a2881e6ddd
[3] https://github.com/TaylanUB/scheme-bytestructures/blob/a6d5d25b26c0c5ef1f5fa38e2472fbf6a32cdf89/bytestructures/body/struct.scm#L110
[4] https://github.com/TaylanUB/scheme-bytestructures/blob/a6d5d25b26c0c5ef1f5fa38e2472fbf6a32cdf89/bytestructures/body/struct.scm#L109
[5] https://github.com/TaylanUB/scheme-bytestructures/blob/a6d5d25b26c0c5ef1f5fa38e2472fbf6a32cdf89/bytestructures/body/struct.scm#L112
[6] https://github.com/TaylanUB/scheme-bytestructures/blob/a6d5d25b26c0c5ef1f5fa38e2472fbf6a32cdf89/run-tests.body.scm#L194
[7] https://github.com/TaylanUB/scheme-bytestructures/issues/47

* * *
```
Group begin: aligned
Test begin:
  test-name: "ref1"
  source-file: "run-tests.body.scm"
  source-line: 194
  source-form: (test-eqv "ref1" 321 (bytestructure-ref bs (quote a)))
Test end:
  result-kind: pass
  actual-value: 321
  expected-value: 321
Test begin:
  test-name: "ref2"
  source-file: "run-tests.body.scm"
  source-line: 196
  source-form: (test-eqv "ref2" 456 (bytestructure-ref bs (quote b)))
Test end:
  result-kind: pass
  actual-value: 456
  expected-value: 456
Test begin:
  test-name: "set1"
  source-file: "run-tests.body.scm"
  source-line: 197
  source-form: (test-eqv "set1" 789 (begin (bytestructure-set! bs (quote a) 789) (bytestructure-ref bs (quote a))))
Test end:
  result-kind: pass
  actual-value: 789
  expected-value: 789
Test begin:
  test-name: "set2"
  source-file: "run-tests.body.scm"
  source-line: 199
  source-form: (test-eqv "set2" 987 (begin (bytestructure-set! bs (quote b) 987) (bytestructure-ref bs (quote b))))
Test end:
  result-kind: pass
  actual-value: 987
  expected-value: 987
Group end: aligned
```
